### PR TITLE
fix most equation references

### DIFF
--- a/lectures/01-Introduction.qmd
+++ b/lectures/01-Introduction.qmd
@@ -24,9 +24,9 @@ Being good Bayesians we are interested in the following computational tasks
 
 At its most fundamental level, [Bayesian inference](https://en.wikipedia.org/wiki/Bayesian_inference) involves applying the sum and product rule of probability theory  to learn a model from some information: 
 
-\begin{equation}\label{eq:bayes}
+$$
     \underbrace{\Pr(\theta|D, M)}_{Posterior}\,\, \underbrace{\Pr(D|M)}_{Evidence} = \underbrace{\Pr(D |\theta, M)}_{Likelihood}\,\, \underbrace{\Pr(\theta | M)}_{Prior}
-\end{equation}
+$$ {#eq-bayes}
 
 where $D$ are the data, $M$ is a model with parameters $\theta$. 
 
@@ -38,9 +38,9 @@ There are two main tasks in Bayesian inference:
 
 First task requires computations with the (unnormalized) posterior $\Pr(\theta|D,M)$ or $\Pr(D|\theta,M)\,\Pr(\theta|M)$. The second task involves computation of the model evidence:
 
-\begin{equation}\label{eq:evidence}
+$$
     \Pr(D|M) = \int \Pr(D|\theta, M)\, \Pr(\theta|M)\, d\theta 
-\end{equation}
+$$ {#eq-evidence}
 
 Other important integrals that need to be computed in Bayesian analysis are:
 
@@ -233,9 +233,10 @@ $$
 e.g. the model evidence used in Bayesian model comparison is $\Pr(D|M) = \mathbb E_{\Pr(\theta|M)}[\Pr(D|\theta,M)]$. 
 
 * The notation
-\begin{equation}\label{eq:sample_from}
+$$
 x \sim p(x)
-\end{equation}
+$$ {#eq-sample_from}
+
 means that $x$ follows the distribution $p$
 
 At $\beta = \frac{\log(1 + \sqrt 2)}{2} \approx 0.44$, something peculiar happens. The "attractive forces" that tend to align neighboring spins become so dominant that large regions form. Across these regions, all spins have a similar orientation. This is a *phase transition*. Similar phenomena occur also in learning large probabilistic models where the prior and the likelihood often favor distinct regions in parameter space. 
@@ -259,21 +260,21 @@ Figure from [McCracken: The Monte Carlo Method](https://www.jstor.org/stable/249
 
 The idea of the Monte Carlo method for probabilistic inference is simple: Instead of computing the integral/sum by systematically visiting all possible states in $\mathcal X$, we (randomly) pick those states that are likely to contribute strongly to the sum/integral:
 
-\begin{equation}\label{eq:sampling}
+$$
 \mathbb{E}_{p}[f] = \int_{\mathcal X} f(x)\, p(x)\,  dx \approx \hat f_S := \frac{1}{S} \sum_{s=1}^S f(x^{(s)})\,\,\,\text{with}\,\,\,  x^{(s)} \sim p(x)
-\end{equation}
+$$ {#eq-sampling}
 where $x^{(s)}$ are $S\in\mathbb N$ samples from $p(x)$ (the index $s$ enumerates all samples) and $\hat f_S$ is a *Monte Carlo estimate* or *Monte Carlo approximation* of $\mathbb E_p[f]$. Our hope is that with $S\to\infty$, the approximation becomes better and better. This is indeed the case, as we will see in a second. 
 
 ### Monte Carlo as density estimation
 
 The Monte Carlo approximation can also be viewed as a *density estimation* approach since the estimate $\hat f_S$ can be interpreted as the expectation under the approximate probability
-\begin{equation}\label{eq:approximate_pdf}
+$$
 \hat p_S(x) = \frac{1}{S} \sum_{s=1}^S \delta(x - x^{(s)})
-\end{equation}
+$$ {#eq-approximate_pdf}
 where $\delta(\cdot)$ is the [delta distribution](https://en.wikipedia.org/wiki/Dirac_delta_function): 
-\begin{equation}\label{eq:sampling2}
+$$
 \hat f_S := \frac{1}{S} \sum_{s=1}^S f(x^{(s)}) = \mathbb E_{\hat p_S}[f]
-\end{equation}
+$$ {#eq-sampling2}
 We approximate the true probability $p(x)$ with a Monte Carlo estimate $\hat p_S(x)$ obtained at $S$ samples $x^{(s)}$ where 
 
 $$
@@ -293,23 +294,25 @@ $$
 
 The Monte Carlo estimate $\hat f_S$ is a random quantity, because with each realization of $x^{(1)}, \ldots, x^{(S)}$ we obtain a different result. We can compute the first two moments of $\hat f_S$:
 
-\begin{equation}\label{eq:MCbias}
+$$
 \mathbb E_{p_S}[\hat f_S] = \frac{1}{S} \sum_{s=1}^S \mathbb{E}_p[f(x^{(s)})] = \mathbb{E}_p[f] =: \mu
-\end{equation}
+$$ {#eq-MCbias}
 That is, the Monte Carlo estimate of $\mathbb E_p[f]$ is __unbiased__.
 
 How accurate is the estimate on average (i.e. how close do we get to the true value if we run many replications of the sampling procedure)? To answer this question, we compute the variance
 
-\begin{eqnarray}\label{eq:MCvariance}
-\nonumber \text{var}[\hat f_S] 
-&=& \frac{1}{S^2} \sum_{s,s'} \mathbb{E}_{p_S}\bigl[(f(x^{(s)}) - \mu) (f(x^{(s')}) - \mu)\bigr] \\
-\nonumber &=& \frac{1}{S^2} \sum_{s,s'} \delta_{s,s'}\, \mathbb{E}_{p}\bigl[(f(x^{(s)}) - \mu)^2\bigr] \\
-&=& \frac{1}{S} \text{var}[f] 
-\end{eqnarray}
+$$
+\begin{aligned}
+    \nonumber \text{var}[\hat f_S] 
+    &= \frac{1}{S^2} \sum_{s,s'} \mathbb{E}_{p_S}\bigl[(f(x^{(s)}) - \mu) (f(x^{(s')}) - \mu)\bigr] \\
+    \nonumber &= \frac{1}{S^2} \sum_{s,s'} \delta_{s,s'}\, \mathbb{E}_{p}\bigl[(f(x^{(s)}) - \mu)^2\bigr] \\
+    &= \frac{1}{S} \text{var}[f] 
+\end{aligned}
+$$ {#eq-MCvariance}
 That is, Monte Carlo error bars shrink like $1/\sqrt{S}$:
-\begin{equation}\label{eq:MCerror}
+$$
 \sigma(\hat f_S) := \sqrt{\text{var}[\hat f_S]} = \sigma(f) / \sqrt{S}
-\end{equation}
+$$ {#eq-MCerror}
 
 where the proportionality constant $\sigma(f)=\sqrt{\text{var}[f]}$ depends on the specific estimation problem. In practice, $\sigma(f)$ is not available (after all we are doing Monte Carlo because we cannot do the sum/integrals that are necessary to compute means and variances...). However, we can use Monte Carlo to estimate $\sigma(f)$.
 
@@ -317,17 +320,17 @@ where the proportionality constant $\sigma(f)=\sqrt{\text{var}[f]}$ depends on t
 
 So far, we studied the behavior of the Monte Carlo estimator for fixed number of samples $S$ and many repetitions. Let us now look at the limit $S\to\infty$. We have (almost surely)
 
-\begin{equation}\label{eq:slln}
+$$
 \hat f_S \overset{S\to\infty}{\longrightarrow} \mu = \mathbb E_p[f]
-\end{equation}
+$$ {#eq-slln}
 
 This result is known as the [*strong law of large numbers*](https://en.wikipedia.org/wiki/Law_of_large_numbers).
 
 If $\text{var}[f] < \infty$, then the [__Central limit theorem__ (CLT)](https://en.wikipedia.org/wiki/Central_limit_theorem), a fundamental theorem in Statistics, guarantees that Monte Carlo works:
 
-\begin{equation}\label{eq:CLT}
+$$
 \hat f_S \overset{S\to\infty}{\longrightarrow} \mathcal N\left(\mathbb E_p[f], \sigma(f)^2/S\right) 
-\end{equation}
+$$ {#eq-CLT}
 
 where $\mathcal N(\mu, \sigma^2)$ is the [Normal distribution](https://en.wikipedia.org/wiki/Normal_distribution) with mean $\mu$ and variance $\sigma$. 
 
@@ -337,9 +340,9 @@ But these are only statistical, asymptotic guarantees for the convergence of Mon
 
 Let us use a simple Monte Carlo approach to estimate $\pi$. We have
 
-\begin{equation}\label{eq:pi}
+$$
 \pi = \int_{[-1,1]^2} \mathbb 1(x^2 + y^2 < 1)\, \, dx dy = \int_{\mathcal X} f(x, y)\, p(x, y)\, dxdy
-\end{equation}
+$$ {#eq-pi}
 
 where $\mathbb 1(\cdot)$ is the indicator function. In this example, the distribution $p(x,y)=1/4$ is the uniform distribution over the square $\mathcal X = [-1, 1]^2$ and $f(x, y) = 4\cdot\mathbb 1(x^2 + y^2 < 1)$. We have:
 
@@ -349,9 +352,9 @@ $$
 
 This integral can be approximated by:
 
-\begin{equation}\label{eq:pi_MC}
+$$
 \pi \approx \frac{1}{S} \sum_{s=1}^S f(x^{(s)}, y^{(s)})
-\end{equation}
+$$ {#eq-pi_MC}
 
 where $(x^{(s)}, y^{(s)})$ are picked randomly from the unit square. The approximate value of $\pi$ is just four times the fraction of sampling points that land in the unit disk.  
 

--- a/lectures/02-Direct-Sampling-Methods.qmd
+++ b/lectures/02-Direct-Sampling-Methods.qmd
@@ -31,7 +31,7 @@ print(f'accuracy: {abs(4*val-np.pi)}')
 
 ## Do we beat the curse of dimensionality?
 
-Although Monte Carlo doesn't depend explicitly on the dimension of the sample space, it does so in practice. If we go back to our expression for the Monte Carlo error (Eq. \ref{eq:MCerror})
+Although Monte Carlo doesn't depend explicitly on the dimension of the sample space, it does so in practice. If we go back to our expression for the Monte Carlo error (Eq. @eq-MCerror)
 
 $$
 \sigma(\hat f_S) = \sigma(f) / \sqrt{S}
@@ -56,10 +56,12 @@ $$
 
 We can compute how the Monte Carlo error scales by evaluating the mean and variance of $f$:
 
-\begin{eqnarray*}
-\mathbb E[f] &=& V(D)\\
-\text{var}[f] &=& \mathbb E[f^2]  - V^2(D) = 2^D V(D) - V^2(D) = \bigl(2^D - V(D)\bigr)\, V(D) 
-\end{eqnarray*}
+$$
+\begin{aligned}
+    \mathbb E[f] &= V(D)\\
+    \text{var}[f] &= \mathbb E[f^2]  - V^2(D) = 2^D V(D) - V^2(D) = \bigl(2^D - V(D)\bigr)\, V(D) 
+\end{aligned}
+$$
 
 Therefore, the error of the above Monte Carlo procedure scales with $D$ as follows:
 
@@ -387,9 +389,9 @@ Assuming that we have a good source for pseudo random numbers, let us first look
 
 How can we use uniform random numbers from $[0, 1]$ to generate samples from $p$? For given $u\sim \mathcal U(0,1)$ pick state $i\in[N]$ such that
 
-\begin{equation}\label{eq:discrete_sampling}
+$$
     i = \min\bigl\{j \in\mathbb N\, :\, \sum_{k=1}^j p_k \ge u  \bigr\}
-\end{equation}
+$$ {#eq-discrete_sampling}
 
 Here and in the following $\mathcal U(0,1)$ denotes the uniform distribution over the unit interval, i.e. $x\sim U(0,1)$ has density $p(x) = \mathbb 1(0 < x < 1)$.  
 
@@ -400,7 +402,7 @@ $$
 $$
 
 
-Criterion (Eq. \ref{eq:discrete_sampling}) picks the interval with $u\in[c_{i-1}, c_{i})=:I_i$. The length of each interval $I_i$ is $c_i - c_{i-1} = p_i$, and equal to the chance of landing in $I_i$. Therefor the generated $x_i$ will follow $p$.   
+Criterion (Eq. @eq-discrete_sampling) picks the interval with $u\in[c_{i-1}, c_{i})=:I_i$. The length of each interval $I_i$ is $c_i - c_{i-1} = p_i$, and equal to the chance of landing in $I_i$. Therefor the generated $x_i$ will follow $p$.   
 
 ```{python}
 # illustration discrete sampling
@@ -426,9 +428,9 @@ fig.tight_layout()
 
 The Poisson distribution is a pmf over the sample space $\mathbb N$, i.e. $x=0, 1, 2, \ldots$ and defined as
 
-\begin{equation}\label{eq:poisson}
+$$
 p(x) = \frac{\lambda^x}{x!} e^{-\lambda}, \,\,\, \lambda > 0
-\end{equation}
+$$ {#eq-poisson}
 
 the parameter $\lambda$ is called *rate*. The mean and variance of $x$ are
 
@@ -500,9 +502,9 @@ Let's first look at the simplest version of sampling from a pdf where the sample
 
 Let $h$ be a *one-to-one mapping* between two one-dimensional sample spaces $h: \mathcal X \to \mathcal Y$, and $h^{-1}$ is the inverse function. If $x\sim p_x(x)$, what is the distribution $p_y(y)$ of $y=h(x)$? To answer this question let us compute the distribution $p_y$:
 
-\begin{equation}\label{eq:transform1d}
+$$
 p_y(y) = \int_{\mathcal X} \delta(y - h(x))\, p_x(x)\, dx = \int_{\mathcal X} \frac{1}{|h'(x)|} \delta(x - h^{-1}(y))\, p_x(x)\, dx = \frac{p_x(h^{-1}(y))}{h'(h^{-1}(y))}
-\end{equation}
+$$ {#eq-transform1d}
 
 where we used the transformation property of the [delta distribution](https://en.wikipedia.org/wiki/Dirac_delta_function). The transformation rule guarantees that normalized pdfs transform into normalized pdfs. 
 
@@ -525,23 +527,23 @@ $$
 
 The [*inversion method*](https://en.wikipedia.org/wiki/Inverse_transform_sampling) is a simple variable transformation method. Let $p(x)$ be a pdf over a sample space $\mathcal X \subset \mathbb R$, then the [*cumulative distribution function* (cdf)](https://en.wikipedia.org/wiki/Cumulative_distribution_function) is:
 
-\begin{equation}\label{eq:cdf}
+$$
 P(y) = \Pr(x \le y) = \mathbb E_p[x \le y] = \int^y_{-\infty} p(x)\, dx
-\end{equation}
+$$ {#eq-cdf}
 
 this is the continuous analog of $c_i$ defined above in the section on sampling discrete models. By construction, $P(x) \in [0, 1]$ for $x \in\mathcal X$. $P(x)$ is continuous and strictly increasing and therefore invertible. Inverse transform sampling uses the following mathematical fact:
 
-\begin{equation}\label{eq:inversion_method}
+$$
 x = P^{-1}(u) \sim p(x)\,\,\,\text{for}\,\,\, u\sim\mathcal U(0,1) 
-\end{equation}
+$$ {#eq-inversion_method}
 
-That is, we can generate random samples from $p(x)$ by generating uniformly distributed random numbers in $[0, 1]$ and map them to $\mathcal X$ with the inverse of the cdf $P^{-1}$. To see that this is a valid sampling procedure, let us compute the distribution of $x=P^{-1}(u)$ using the transformation rule (Eq. \ref{eq:transform1d}): We have
+That is, we can generate random samples from $p(x)$ by generating uniformly distributed random numbers in $[0, 1]$ and map them to $\mathcal X$ with the inverse of the cdf $P^{-1}$. To see that this is a valid sampling procedure, let us compute the distribution of $x=P^{-1}(u)$ using the transformation rule (Eq. @eq-transform1d): We have
 
 $$
 \frac{d\, P^{-1}(u)}{d\, u} = \frac{1}{P'(P^{-1}(u))} = \frac{1}{p(P^{-1}(u))}
 $$
 
-Plugging this expression into (Eq. \ref{eq:transform1d}) yields
+Plugging this expression into (Eq. @eq-transform1d) yields
 
 $$
 p_x(x) = \frac{p_u(P(x))}{(P^{-1})'(P(x))} = \frac{1}{1 / p(x)} = p(x)
@@ -706,16 +708,18 @@ fig.tight_layout()
     
 ```
 
-In principle, the inverse transformation approach (Eq. \ref{eq:inversion_method}) generalizes to multiple dimensions (see, for example, Murray Rosenblatt: [Remarks on a Multivariate Transformation](https://www.jstor.org/stable/2236692?seq=1#metadata_info_tab_contents)):
+In principle, the inverse transformation approach (Eq. @eq-inversion_method) generalizes to multiple dimensions (see, for example, Murray Rosenblatt: [Remarks on a Multivariate Transformation](https://www.jstor.org/stable/2236692?seq=1#metadata_info_tab_contents)):
 
-\begin{eqnarray*}\label{eq:multivariate_transform}
+$$
 %
-P_1(x_1') &=& \Pr(x_1 < x_1') = \int \mathbb 1(x_1 \le x_1')\, p(x_1, \ldots, x_D)\, dx_1 \cdots dx_D \\
-%
-P_2(x_2'\mid{}x_1) &=& \Pr(x_2 < x_2' \mid{}x_1) = \int \mathbb 1(x_2 \le x_2')\, p(x_2, \ldots, x_D\mid{}x_1)\, dx_2 \cdots dx_D \\
- &\vdots&  \\
-P_D(x_D'\mid{}x_{D-1}, \ldots, x_{1}) &=& \Pr(x_D < x_D'\mid{}x_{D-1}, \ldots, x_{1}) = \int \mathbb 1(x_D \le x_D')\, p(x_D\mid{}x_{D-1}, \ldots, x_{1})\, dx_D \\
-\end{eqnarray*}
+\begin{aligned}
+    P_1(x_1') &= \Pr(x_1 < x_1') = \int \mathbb 1(x_1 \le x_1')\, p(x_1, \ldots, x_D)\, dx_1 \cdots dx_D \\
+    %
+    P_2(x_2'\mid{}x_1) &= \Pr(x_2 < x_2' \mid{}x_1) = \int \mathbb 1(x_2 \le x_2')\, p(x_2, \ldots, x_D\mid{}x_1)\, dx_2 \cdots dx_D \\
+    &\vdots  \\
+    P_D(x_D'\mid{}x_{D-1}, \ldots, x_{1}) &= \Pr(x_D < x_D'\mid{}x_{D-1}, \ldots, x_{1}) = \int \mathbb 1(x_D \le x_D')\, p(x_D\mid{}x_{D-1}, \ldots, x_{1})\, dx_D
+\end{aligned}
+$$ {#eq-multivariate_transform}
 
 However, only in very rare cases is it possible to compute the multivariate cumulative distribution function in higher dimensional spaces, let alone invert it in closed form. 
 

--- a/lectures/03-Rejection-and-Importance-Sampling.qmd
+++ b/lectures/03-Rejection-and-Importance-Sampling.qmd
@@ -147,9 +147,9 @@ where $x, b \in \mathbb R^D$ and $A\in\mathbb R^{D\times D}$ is positive definit
 
 The [Erlang distribution](https://en.wikipedia.org/wiki/Erlang_distribution), a special version of the [Gamma distribution](https://en.wikipedia.org/wiki/Gamma_distribution), has the functional form
 
-\begin{equation}\label{eq:erlang}
+$$
     p(x|k, \lambda) = \frac{\lambda^k}{\Gamma(k)} x^{k - 1} e^{-\lambda x}, \, k \in \mathbb N, \, k> 0,\, \lambda > 0
-\end{equation}
+$$ {#eq-erlang}
 
 We can use exponentially distributed random variables $z_i \sim \lambda e^{-\lambda z_i}, i=1, \ldots, k$ to produce an Erlang variate. Define $z_i = x y_i$ with $y_i\in[0, 1]$ for $1 \le i \le k-1$ and $z_k = x \bigl(1-\sum_{i=1}^{k-1} y_i\bigr)$, then $x = \sum_i z_i$. The Jacobian of the parameter transform is
 
@@ -222,15 +222,15 @@ Direct sampling methods are specifically designed for particular target distribu
 
 [*Rejection sampling*](https://en.wikipedia.org/wiki/Rejection_sampling) is an early sampling approach that has been developed by von Neumann. The idea is to use a helper distribution $q$ from which we can sample easily in order to sample from a more complicated model $p$. To be a valid proposal distribution, $q$ must satisfy
 
-\begin{equation}\label{eq:rejection_proposal}
+$$
     p(x) \le M q(x)
-\end{equation}
+$$ {#eq-rejection_proposal}
 
 for a constant $M$ which implies $M\ge 1$, since $p$ and $q$ are normalized pdfs. Moreover, the support of $p$ should be contained in the support of the proposal distribution $q$. Let's define the ratio 
 
-\begin{equation}\label{eq:rejection_accprob}
-r(x) := \frac{p(x)}{M q(x)}
-\end{equation}
+$$
+    r(x) := \frac{p(x)}{M q(x)}
+$$ {#eq-rejection_accprob}
 
 which is smaller than or equal to 1 for all $x$ with $q(x)>0$, otherwise we set $r(x) = 1$. 
 
@@ -354,11 +354,11 @@ $$
 
 It is straight forward to compute this distribution. We have $p(x\mid{}a=1) = p(x, a=1)\, /\, p(a=1)$. We need to compute the marginal probability $p(a=1)$:
 
-\begin{equation}\label{eq:rs-acceptance}
+$$
 p(a=1) = \int p(x, a=1)\, dx = \int q(x)\, r(x)\, dx = \int q(x)\, \frac{p(x)}{Mq(x)}\, dx = \frac{1}{M}
-\end{equation}
+$$ {#eq-rs-acceptance}
 
-since $p$ is normalized. Equation (\ref{eq:rs-acceptance}) tells us that the average probability to propose an acceptable sample is $M^{-1}$. We can now compute the desired conditional distribution $p(x\mid{}a=1)$: 
+since $p$ is normalized. Equation (@eq-rs-acceptance) tells us that the average probability to propose an acceptable sample is $M^{-1}$. We can now compute the desired conditional distribution $p(x\mid{}a=1)$: 
 
 $$
 p(x\mid{}a=1) = \frac{p(x, a=1)}{p(a=1)} = M q(x)\, r(x) = M q(x)\, \frac{p(x)}{M q(x)} = p(x)\, .
@@ -511,10 +511,12 @@ Finding tight bounds in high dimensions is very difficult. Moreover, the volume 
 
 Often, it is not possible to normalize a probabilistic model. So we only know $p^*(x)$ and $q^*(x)$ with
 
-\begin{eqnarray*}
-p(x) &=& \frac{p^*(x)}{Z_p}\,\,\,\text{with}\,\,\, Z_p = \int_{\mathcal X} p^*(x)\, dx < \infty\\ 
-q(x) &=& \frac{q^*(x)}{Z_q}\,\,\,\text{with}\,\,\, Z_q = \int_{\mathcal X} q^*(x)\, dx < \infty\, . 
-\end{eqnarray*}
+$$
+\begin{aligned}
+    p(x) &= \frac{p^*(x)}{Z_p}\,\,\,\text{with}\,\,\, Z_p = \int_{\mathcal X} p^*(x)\, dx < \infty\\ 
+    q(x) &= \frac{q^*(x)}{Z_q}\,\,\,\text{with}\,\,\, Z_q = \int_{\mathcal X} q^*(x)\, dx < \infty\, . 
+\end{aligned}
+$$
 
 The condition that has to be satisfied is now
 
@@ -522,7 +524,7 @@ $$
 p^*(x) \le M q^*(x)\,\,\, \Rightarrow M \ge Z_p/Z_q\, .
 $$
 
-In analogy to Eq. (\ref{eq:rejection_accprob}), the acceptance probability changes to
+In analogy to Eq. (@eq-rejection_accprob), the acceptance probability changes to
 
 $$
 r(x) = \frac{p^*(x)}{M q^*(x)} \le 1
@@ -575,17 +577,17 @@ The algorithm produces random samples $x^{(s)}$ and (importance) weights $w^{(s)
 
 Expectation values are then approximated by
 
-\begin{equation}\label{eq:IS}
-\mathbb E_p[f] \approx \hat f_{\text{IS}} := \frac{1}{S} \sum_{s=1}^S w^{(s)} \, f(x^{(s)})
-\end{equation}
+$$
+    \mathbb E_p[f] \approx \hat f_{\text{IS}} := \frac{1}{S} \sum_{s=1}^S w^{(s)} \, f(x^{(s)})
+$$ {#eq-IS}
 
 The right hand side can be interpreted as the expectation of $f$ under the approximate density
 
-\begin{equation}\label{eq:is-approximation}
-\hat p_S(x) = \frac{1}{S} \sum_{s=1}^S w^{(s)} \delta\bigl(x - x^{(s)}\bigr)\, .
-\end{equation}
+$$
+    \hat p_S(x) = \frac{1}{S} \sum_{s=1}^S w^{(s)} \delta\bigl(x - x^{(s)}\bigr)\, .
+$$ {#eq-is-approximation}
 
-This is a generalization of the approximate density introduced earlier in Eq. (\ref{eq:approximate_pdf}). 
+This is a generalization of the approximate density introduced earlier in Eq. (@eq-approximate_pdf). 
 
 Let us again use a Gaussian target and a Cauchy proposal to illustrate the sampling algorithm:
 
@@ -636,7 +638,7 @@ fig.tight_layout()
 
 ### Properties of importance sampling
 
-The importance sampling estimator (Eq. \ref{eq:IS}) is unbiased: The $S$ samples follow the joint distribution $q_S(x^{(1)}, \ldots, x^{(S)}) = \prod_s q(x^{(s)})$, and the expectation of the importance sampling estimator is
+The importance sampling estimator (Eq. @eq-IS) is unbiased: The $S$ samples follow the joint distribution $q_S(x^{(1)}, \ldots, x^{(S)}) = \prod_s q(x^{(s)})$, and the expectation of the importance sampling estimator is
 
 $$
 \mathbb E_{q_S}[\hat f_{\text{IS}}] 
@@ -647,7 +649,7 @@ $$
 
 The law of large numbers guarantees that $\hat f_{\text{IS}} \to \mathbb E_p[f]$ for $S\to\infty$. 
 
-Since the importance sampling (IS) estimator $\hat f_{\text{IS}}$ is simply the Monte Carlo estimator for $w(x)f(x)$ and sampling distribution $q$, also the variance is readily available from Eq. (\ref{eq:MCvariance}): 
+Since the importance sampling (IS) estimator $\hat f_{\text{IS}}$ is simply the Monte Carlo estimator for $w(x)f(x)$ and sampling distribution $q$, also the variance is readily available from Eq. (@eq-MCvariance): 
 
 $$
 \text{var}[\hat f_{\text{IS}}] = \frac{1}{S} \text{var}_q[wf] \, . 
@@ -659,9 +661,9 @@ $$
 \text{var}_q[wf] = \underbrace{\mathbb E_q[(wf)^2]}_{\mathbb E_p[wf^2]} - \bigl(\underbrace{\mathbb E_q[wf]}_{\mathbb E_p[f]}\bigr)^2 = \mathbb E_p[wf^2] - \bigl( \mathbb E_p[f] \bigr)^2
 $$
 
-\begin{equation}\label{eq:ISvariance}
-\text{var}[\hat f_{\text{IS}}] = \frac{1}{S} \biggl( \mathbb E_p[wf^2] - \bigl( \mathbb E_p[f] \bigr)^2 \biggr)\, . 
-\end{equation}
+$$
+    \text{var}[\hat f_{\text{IS}}] = \frac{1}{S} \biggl( \mathbb E_p[wf^2] - \bigl( \mathbb E_p[f] \bigr)^2 \biggr)\, . 
+$$ {#eq-ISvariance}
 
 Like the error of the standard Monte Carlo approximation, the error of the IS estimator shrinks with $1/\sqrt{S}$. We can also minimize the variance of the IS estimator as a functional of the proposal distribution (subject to the constraint $\int q(x)\, dx = 1$), which can be achieved by minimizing the Lagrangian $\mathbb E_p[p/q\, f^2] + \lambda (1-\int q(x) dx)$ resulting in the optimal IS proposal:
 
@@ -710,25 +712,25 @@ $$
 
 The IS estimator for the ratio of normalizing constants is
 
-\begin{equation}\label{eq:ISratio}
-(\widehat{Z_p/Z_q})_{\text{IS}} = \frac{1}{S} \sum_{s=1}^S \frac{p^*(x^{(s)})}{q^*(x^{(s)})} \, .
-\end{equation}
+$$
+    (\widehat{Z_p/Z_q})_{\text{IS}} = \frac{1}{S} \sum_{s=1}^S \frac{p^*(x^{(s)})}{q^*(x^{(s)})} \, .
+$$ {#eq-ISratio}
 
-Plugging this estimator into standard IS estimator (Eq. \ref{eq:IS}) yields the *self-normalized* importance sampling (NIS) estimator
+Plugging this estimator into standard IS estimator (Eq. @eq-IS) yields the *self-normalized* importance sampling (NIS) estimator
 
-\begin{equation}\label{eq:ISselfnormalized}
+$$
 \hat f_{\text{NIS}} = \frac{\sum_{s=1}^S \frac{p^*(x^{(s)})}{q^*(x^{(s)})}\, f(x^{(s)})}{ \sum_{s=1}^S \frac{p^*(x^{(s)})}{q^*(x^{(s)})}} = \frac{\sum_{s=1}^S w^{(s)}\, f(x^{(s)})}{ \sum_{s=1}^S w^{(s)}}
-\end{equation}
+$$ {#eq-ISselfnormalized}
 
 In contrast to $\hat f_{\text{IS}}$, the self-noramlized IS estimator $\hat f_{\text{NIS}}$ is biased, but strongly consistent, meaning that for $S\to\infty$ the NIS estimator converges to the correct estimate: $\hat f_{\text{NIS}} \to \mathbb E_p[f]$. The asymptotic variance of the estimator can be approximated by
 
-\begin{equation}\label{eq:NISvar}
+$$
 \text{var}_{\text{as}}[\hat f_{\text{NIS}}] =  \frac{\frac{1}{S} \sum_s [w^{(s)}]^2 \bigl(f(x^{(s)}) - \hat f_{\text{NIS}}\bigr)^2}{\bigl[\frac{1}{S} \sum_s w^{(s)}\bigr]^2}\, .   
-\end{equation}
+$$ {#eq-NISvar}
 
 ### Effective sample size
 
-The [effective sampling size (ESS)](https://en.wikipedia.org/wiki/Effective_sample_size) is the number of *independent* samples $S_{\text{eff}}$ that would result in the same variance as the NIS estimator (Eq. \ref{eq:NISvar}). To compute ESS, we match the asymptotic variance of $\hat f_{\text{NIS}}$ with the variance resulting from $S_{\text{eff}}$:    
+The [effective sampling size (ESS)](https://en.wikipedia.org/wiki/Effective_sample_size) is the number of *independent* samples $S_{\text{eff}}$ that would result in the same variance as the NIS estimator (Eq. @eq-NISvar). To compute ESS, we match the asymptotic variance of $\hat f_{\text{NIS}}$ with the variance resulting from $S_{\text{eff}}$:    
 
 $$
 \frac{1}{S} \text{var}_{\text{as}}[\hat f_{\text{NIS}}] = \frac{\sum_s \bigl[w^{(s)}\bigr]^2 \bigl(f(x^{(s)}) - \hat f_{\text{NIS}} \bigr)^2}{\bigl[\sum_s w^{(s)}\bigr]^2} = \frac{\sigma^2}{S_{\text{eff}}}
@@ -736,9 +738,9 @@ $$
 
 where $\sigma^2 = \text{var}_p[f]$. For $f(x^{(s)}) - \hat f_{\text{NIS}} \approx \sigma$, we obtain:
 
-\begin{equation}\label{eq:ESS}
+$$
 S_{\text{eff}} = \frac{\bigl[\sum_s w^{(s)}\bigr]^2}{\sum_s \bigr[w^{(s)}\bigl]^2}
-\end{equation}
+$$ {#eq-ESS}
 
 The two extreme cases are:
 

--- a/lectures/04-Markov-Chain-Monte-Carlo.qmd
+++ b/lectures/04-Markov-Chain-Monte-Carlo.qmd
@@ -34,9 +34,9 @@ where $q(x)$ is a proposal or helper distribution.
 
 The idea of [__Markov chain Monte Carlo (MCMC)__](https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) methods is to give up the *independence* of successive samples and generate sequences of states where $x^{(s)}$ depends on the previous sample $x^{(s-1)}$. Our hope is that also when introducing these correlations, the Monte Carlo approximation
 
-\begin{equation}\label{eq:MCapproximation}
+$$
 \frac{1}{S} \sum_{s=1}^S f\bigl(x^{(s)}\bigr) \approx \mathbb E_p[f]
-\end{equation}
+$$ {#eq-MCapproximation}
 
 is still valid. This is justified by our intuition that as long as we run the simulation long enough correlations between two states $x^{(s')}$ and $x^{(s)}$ will vanish with large $|s'-s|$, and the samples $x^{(s)}$ will approximately follow $p(x)$ for large $s$
 
@@ -48,9 +48,9 @@ Markov chains are models for dynamical systems with possibly uncertain transitio
 
 A (first order) [*Markov chain*](https://en.wikipedia.org/wiki/Markov_chain) is a *memoryless* stochastic process $\left(x^{(s)}\right)_{s\ge 0}$ that has the following [property](https://en.wikipedia.org/wiki/Markov_property)
 
-\begin{equation}\label{eq:MarkovChain}
+$$
 \Pr\bigl(x^{(s+1)} \mid x^{(s)}, \ldots, x^{(1)}\bigr) = \Pr\bigl(x^{(s+1)} \mid x^{(s)}\bigr)
-\end{equation}
+$$ {#eq-MarkovChain}
 
 with $x^{(s)} \in \mathcal X$. That is, the probability of finding the system in state $x^{(s+1)}$ only depends on the *last* state $x^{(s)}$, not on the previous states before the last state. In this sense, Markov chains have no memory. A Markov chain is uniquely characterized by 
 
@@ -74,44 +74,44 @@ For example the two-state Markov chain with transition probabilities $\Pr(x_2\mi
 
 Since the transition probability depends only on the last state, we can summarize all probabilities in a *transition matrix*
 
-\begin{equation}\label{eq:transition-matrix}
+$$
     P(x, y) = \Pr(x \mid y)
-\end{equation}
+$$ {#eq-transition-matrix}
 
 For continuous sample spaces, the transition matrix becomes a transition operator or [Markov kernel](https://en.wikipedia.org/wiki/Markov_kernel). For the above two-state system we have
 
-\begin{equation}\label{eq:twostate}
+$$
 P(x, y) = \begin{pmatrix}
 1 - \alpha & \beta \\
 \alpha & 1 - \beta \\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-twostate}
 
 where $\alpha, \beta \in [0, 1]$.
 
 In discrete sample spaces, $P(x, y)$ is the probability that we jump from state $y\in\mathcal X$ to state $x\in\mathcal X$. Because we are dealing with conditional probabilities, we have
 
-\begin{equation}\label{eq:transition-matrix2}
+$$
 \sum_{x\in\mathcal X} P(x, y) = 1, \,\,\, P(x, y) \ge 0\, .
-\end{equation}
+$$ {#eq-transition-matrix2}
 
 The first condition can be written in matrix-vector notation
 
-\begin{equation}\label{eq:leftstochastic}
+$$
 \mathbb 1^T\!P = \mathbb 1^T
-\end{equation}
+$$ {#eq-leftstochastic}
 
 where 
 
-\begin{equation}\label{eq:one}
+$$
 \mathbb 1 = \begin{pmatrix}
 1 \\
 \vdots\\
 1\\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-one}
 
-is a column vector whose elements are all one, and $P$ is the transition matrix. Non-negative square matrices that satisfy condition (\ref{eq:leftstochastic}) are called [*(left) stochastic*](https://en.wikipedia.org/wiki/Stochastic_matrix) matrices. The qualifier "left" stems from the fact that the *columns* of $P(x, y)$ are probability vectors, so multiplication with $\mathbb 1^T$ from the left produces one for each column. 
+is a column vector whose elements are all one, and $P$ is the transition matrix. Non-negative square matrices that satisfy condition (@eq-leftstochastic) are called [*(left) stochastic*](https://en.wikipedia.org/wiki/Stochastic_matrix) matrices. The qualifier "left" stems from the fact that the *columns* of $P(x, y)$ are probability vectors, so multiplication with $\mathbb 1^T$ from the left produces one for each column. 
 
 #### Left versus right stochastic matrices
 
@@ -188,16 +188,16 @@ $$
 
 The marginal distribution of the $(s+1)$-th state in a Markov chain follows the distribution
 
-\begin{equation}\label{eq:marginalMC}
+$$
 p^{(s+1)}(x) = \sum_{y\in\mathcal X} P(x, y)\, p^{(s)}(y)\, . 
-\end{equation}
+$$ {#eq-marginalMC}
 
 Repeating the same argument for $p^{(s)}$, we have
 
-\begin{equation}\label{eq:marginalMC2}
+$$
 p^{(s+1)}(x) = \sum_{y, z\in\mathcal X} P(x, y)\, P(y, z) \, p^{(s-1)}(z) = 
 \sum_{z\in\mathcal X} \left(\sum_{y\in\mathcal X} P(x, y)\, P(y, z) \right) \, p^{(s-1)}(z)\, . 
-\end{equation}
+$$ {#eq-marginalMC2}
 
 The expression in brackets, $\sum_{y\in\mathcal X} P(x, y)\, P(y, z)$, is the transition matrix for making two successive transitions. By generalizing the argument, we obtain the [Chapman-Kolmogorov equation](https://en.wikipedia.org/wiki/Chapman%E2%80%93Kolmogorov_equation).
 
@@ -217,9 +217,9 @@ $$
 
 The matrix power $P^s$ is the matrix analog of the power of scalar quantities: 
 
-\begin{equation}\label{eq:matrix_power}
+$$
 P^s = \underbrace{P \cdot P\cdots P}_{s\text{ terms}} 
-\end{equation}
+$$ {#eq-matrix_power}
 
 where the dot "$\cdot$" indicates matrix multiplication. It is straightforward to see that if $P$ is stochastic, then $P^s$ for $s\ge 1$ is also stochastic. The matrix power $P^s$ *propagates* the distribution of states by $s$ time steps.  
 
@@ -257,9 +257,9 @@ If we keep on taking powers of $P$, the resulting matrix will converge to a low-
 
 The states with $|\lambda |=1$ play a crucial role in the long term behavior of the Markov chain. The left stochasticity of $P$ is the requirement that $\mathbb 1$ is a left eigenvector with eigenvalue 1. Since left and right eigenvalues coincide, there is at least one *right* eigenvector $\pi$ with eigenvalue one:
 
-\begin{equation}\label{eq:stationary}
+$$
 P\pi = \pi
-\end{equation}
+$$ {#eq-stationary}
 
 If $\pi$ is normalized such that $\mathbb 1^T\!\pi=1$, then $\pi$ is a __stationary__ or __invariant__ distribution of $P$. 
 
@@ -303,11 +303,11 @@ This is also an example of an [*absorbing Markov chain*](https://en.wikipedia.or
 
 An alternative definition of an irreducible Markov chain goes as follows: For all pairs $x, y \in \mathcal X$ there exists $s(x,y)\in \mathbb N$ such that
 
-\begin{equation}\label{eq:irreducible}
+$$
 \Pr\bigl(x^{(s)}=x\mid x^{(0)} = y\bigr) = (P^s)(x, y) > 0
-\end{equation}
+$$ {#eq-irreducible}
 
-note that $s(x,y)$ is in general different for every pair of states $x, y \in\mathcal X$. The intuition behind this notion of irreducibility is that "all states can be reached from all other states". [Häggström](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.24.9739&rep=rep1&type=pdf) uses the following terminology: If two states satisfy the irreducibility condition (\ref{eq:irreducible}), then $x$ is said to *communicate* with $y$, i.e. $y$ can be reached from $x$ in a finite time, which is symbolized by $x\to y$. Two states $x$ and $y$ *intercommunicate*, if $x\to y$ and $y\to x$, which is denoted by $x\leftrightarrow y$ (so there exists a path from $x$ to $y$ with non-vanishing probability, and likewise a path from $y$ back to $x$). Using this terminology, a Markov chain is irreducible, if $x \leftrightarrow y$ for all $x, y \in \mathcal X$. This gives us also a hint for verifying irreducibility by checking if the *transition graph* of a Markov chain is [strongly connected](https://en.wikipedia.org/wiki/Strongly_connected_component).
+note that $s(x,y)$ is in general different for every pair of states $x, y \in\mathcal X$. The intuition behind this notion of irreducibility is that "all states can be reached from all other states". [Häggström](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.24.9739&rep=rep1&type=pdf) uses the following terminology: If two states satisfy the irreducibility condition (@eq-irreducible), then $x$ is said to *communicate* with $y$, i.e. $y$ can be reached from $x$ in a finite time, which is symbolized by $x\to y$. Two states $x$ and $y$ *intercommunicate*, if $x\to y$ and $y\to x$, which is denoted by $x\leftrightarrow y$ (so there exists a path from $x$ to $y$ with non-vanishing probability, and likewise a path from $y$ back to $x$). Using this terminology, a Markov chain is irreducible, if $x \leftrightarrow y$ for all $x, y \in \mathcal X$. This gives us also a hint for verifying irreducibility by checking if the *transition graph* of a Markov chain is [strongly connected](https://en.wikipedia.org/wiki/Strongly_connected_component).
 
 On the other hand, if a Markov chain is reducible, then the analysis of its long-term behavior can be reduced to the analysis of the long-term behavior of one or more Markov chains with smaller state space.
 
@@ -317,9 +317,9 @@ To illustrate the concept of irreducibility let us come back to the linear congr
 
 In lecture 2, we studied linear congruential generators based on the recurrence relation
 
-\begin{equation}\label{eq:LCG}
+$$
 x^{(s+1)} = (a x^{(s)} + c)\, \text{mod}\, m 
-\end{equation}
+$$ {#eq-LCG}
 
 with  
 
@@ -446,7 +446,7 @@ ax[2].set_ylabel(r'spectrum $|FT|$')
 fig.tight_layout()
 ```
 
-We can now analyze this LCG by using Markov chain methods. The recurrence relation (\ref{eq:LCG}) defines a Markov chain with deterministic transitions:
+We can now analyze this LCG by using Markov chain methods. The recurrence relation (@eq-LCG) defines a Markov chain with deterministic transitions:
 
 $$
 P(x, y) = \left\{\begin{array}{c l}
@@ -535,9 +535,9 @@ fig.tight_layout()
 
 The period of a state $x\in\mathcal X$ is defined as
 
-\begin{equation}\label{eq:period}
+$$
 d(x) = \text{gcd}\left\{s \ge 1 : P^s(x, x) > 0\right\} 
-\end{equation}
+$$ {#eq-period}
 
 where $\text{gcd}\{a_1, a_2, \ldots\}$ is the [greatest common divisor](https://en.wikipedia.org/wiki/Greatest_common_divisor) of the natural numbers $a_1, a_2, \ldots \in \mathbb N$. The period of a state $x$ is the greatest common divisor of the times that the chain can return (i.e. has positive probability of returning) to $x$, given that we start in $x$. 
 
@@ -568,56 +568,56 @@ For this Markov chain both states, $x_1$ and $x_2$, have a period of two, since 
 
 We have
 
-\begin{equation}\label{eq:twostate2}
+$$
 P(x, y) = \begin{pmatrix}
 1 - \alpha & \beta \\
 \alpha & 1 - \beta \\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-twostate2}
 
 with eigenvalues $1$ and $1-\alpha-\beta$ and corresponding (right) eigenvectors:
 
-\begin{equation}\label{eq:twostate-decomposition}
+$$
 \pi = \frac{1}{\alpha+\beta} \begin{pmatrix}
 \beta \\ \alpha
 \end{pmatrix}, \,\,\,
 \text{and}\,\,\,  \begin{pmatrix}
 1 \\ -1 \\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-twostate-decomposition}
 
 assuming $\alpha>0$ or $\beta>0$. 
 
 In case $\alpha=\beta=0$:
 
-\begin{equation}\label{eq:twostate3}
+$$
 P(x, y) = \begin{pmatrix}
 1  & 0 \\
 0 & 1  \\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-twostate3}
 
 all two state distributions are stationary with eigenvalue one. In particular, we have eigenvectors
 
-\begin{equation}\label{eq:decomposition2}
+$$
 \begin{pmatrix}
 1 \\ 0
 \end{pmatrix}, \,\,\,
 \begin{pmatrix}
 0 \\ 1 \\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-decomposition2}
 
 corresponding to two recurrent classes, and $P$ is reducible.
 
 In case $\alpha=\beta=1$:
 
-\begin{equation}\label{eq:twostate4}
+$$
 P(x, y) = \begin{pmatrix}
 0  & 1 \\
 1 & 0  \\
 \end{pmatrix}
-\end{equation}
+$$ {#eq-twostate4}
 
 the eigenvalues are $1$ and $-1$ with eigenvectors
 

--- a/lectures/05-Metropolis-Hastings.qmd
+++ b/lectures/05-Metropolis-Hastings.qmd
@@ -40,11 +40,11 @@ So only if the Markov is both *irreducible* and *aperiodic*, then we have a uniq
 
 Irreducibility and aperiodicity implies that $\pi$ is unique (see, for example, [Diaconis: The Markov Chain Monte Carlo Revolution](https://www.ams.org/journals/bull/2009-46-02/S0273-0979-08-01238-X/)) and powers of $P$ converge to a rank one matrix
 
-\begin{equation}\label{eq:fundamental}
+$$
 P^S(x, y) \to \pi(x)
-\end{equation}
+$$ {#eq-fundamental}
 
-for $S\to\infty$ and all $x, y \in\mathcal X$. Equation (\ref{eq:fundamental}) means that we can start from any initial state $y\in\mathcal X$ with $\pi(y) > 0$ and will eventually produce samples from the stationary distribution $\pi$. Another way to express this *convergence in distribution* is:
+for $S\to\infty$ and all $x, y \in\mathcal X$. Equation (@eq-fundamental) means that we can start from any initial state $y\in\mathcal X$ with $\pi(y) > 0$ and will eventually produce samples from the stationary distribution $\pi$. Another way to express this *convergence in distribution* is:
 
 $$
 |P^S p - \pi| \to 0
@@ -60,7 +60,7 @@ That is, if $P$ is irreducible and aperiodic, then matrix powers of $P$ converge
 
 The fundamental theorem for Markov chains follows from the [Perron-Frobenius theorem](https://en.wikipedia.org/wiki/Perron%E2%80%93Frobenius_theorem) for non-negative matrices and the irreducibility of $P$. 
 
-Why does theorem (\ref{eq:fundamental}) have implications for sampling? As we saw in the previous lectures, it might be difficult to sample a probabilistic model directly. Sometimes variable transformations allow us to sample a model directly, but this is only rarely the case for complex models. When resorting to rejection or importance sampling, it is generally difficult to find a good proposal distribution. On the other hand, simulation of a Markov chain is simple to implement (see algorithm above): we just have to move from $x$ to $y$ according to $P(y, x)$. No matter where we start in sample space, the states that we produce by simulating a Markov chain will eventually follow the stationary distribution. 
+Why does theorem (@eq-fundamental) have implications for sampling? As we saw in the previous lectures, it might be difficult to sample a probabilistic model directly. Sometimes variable transformations allow us to sample a model directly, but this is only rarely the case for complex models. When resorting to rejection or importance sampling, it is generally difficult to find a good proposal distribution. On the other hand, simulation of a Markov chain is simple to implement (see algorithm above): we just have to move from $x$ to $y$ according to $P(y, x)$. No matter where we start in sample space, the states that we produce by simulating a Markov chain will eventually follow the stationary distribution. 
 
 But there is still something missing in order to use the simulation of a Markov chain for probabilistic inference. In our setting, we are given a probabilistic model $p$ (our target distribution) rather than a transition matrix $P$. So we are still facing the challenge of designing a suitable Markov chain that has the desired target as its stationary distribution. This problem has been solved in a very ingenious fashion by Metropolis et al., as we will see soon. 
 
@@ -123,9 +123,9 @@ Before we explain the Metropolis algorithm, let us briefly state the convergence
 
 Irreducibility and aperiodicity of a stochastic transition matrix implies a strong law of large numbers for Markov chains: 
 
-\begin{equation}\label{eq:lln_markov}
+$$
 \frac{1}{S} \sum_{s=1}^S f\bigl(x^{(s)}\bigr) \to \mathbb E_{\pi}[f]
-\end{equation}
+$$ {#eq-lln_markov}
 
 where $x^{(s)} \sim \Pr\bigl(x\mid x^{(s-1)}\bigr) = P\bigl(x, x^{(s-1)}\bigr)$ is an irreducible, aperiodic Markov chain with stationary distribution $\pi$. Therefore, simulating a Markov chain produces samples that can be used to approximate an expectation similar to the approximation in standard Monte Carlo or importance sampling. 
 
@@ -135,28 +135,30 @@ Analogous to the standard Monte Carlo approximation, Markov chain Monte Carlo (M
 
 A very important concept to verify stationarity of a Markov chain $P$ is *reversibility*. A Markov chain is *$\pi$-reversible* if the transition matrix satisfies the *detailed balance* equations
 
-\begin{equation}\label{eq:reversible}
+$$
 P(x, y)\, \pi(y) = P(y, x)\, \pi(x)
-\end{equation}
+$$ {#eq-reversible}
 
-for all $x, y \in \mathcal X$ for some distribution $\pi$. From the point of view of probability flow across the transition graph, the detailed balance equations (\ref{eq:reversible}) state that "the amount of probability mass flowing from a source state $x$ to a sink $y$ via the directed edge with capacity $P(y, x)$ equals the probability mass flowing backwards." So the dynamics across the transition graph is in a steady state. As a consequence, reversibility implies that $\pi$ is an invariant distribution:
+for all $x, y \in \mathcal X$ for some distribution $\pi$. From the point of view of probability flow across the transition graph, the detailed balance equations (@eq-reversible) state that "the amount of probability mass flowing from a source state $x$ to a sink $y$ via the directed edge with capacity $P(y, x)$ equals the probability mass flowing backwards." So the dynamics across the transition graph is in a steady state. As a consequence, reversibility implies that $\pi$ is an invariant distribution:
 
-\begin{equation}\label{eq:reversible_invariance}
+$$
 \sum_{y\in\mathcal X} P(x, y)\pi(y) = \sum_{y\in\mathcal X} P(y, x) \pi(x) = \pi(x)\, .
-\end{equation}
+$$ {#eq-reversible_invariance}
 
 Therefore, to verify that a distribution of interest (our target distribution) is the invariant distribution of a Markov chain, we can simply check if the transition matrix satisfies detailed balance with respect to the target distribution. 
 
-The contrary to (\ref{eq:reversible_invariance}) is __not__ true: The fact that $\pi$ is a stationary distribution of the transition matrix $P$ does not imply, that $P$ is $\pi$-reversible. 
+The contrary to (@eq-reversible_invariance) is __not__ true: The fact that $\pi$ is a stationary distribution of the transition matrix $P$ does not imply, that $P$ is $\pi$-reversible. 
 
 If we start a Markov chain in the stationary distribution, $p^{(0)} = \pi$, then
-\begin{eqnarray*}\label{eq:forward-backward}
-\Pr\bigl(x_S = x^{(S)}, \ldots x_0=x^{(0)}\bigr) &=& 
-\prod_{s=1}^S P\bigl(x^{(s)}, x^{(s-1)}\bigr)\,  \pi\bigl(x^{(0)}\bigr)\\
-&=&
-\prod_{s=1}^S P\bigl(x^{(s-1)}, x^{(s)}\bigr)\, \pi\bigl(x^{(S)}\bigr) \\
-&=& \Pr\bigl(x_S = x^{(0)}, \ldots x_0=x^{(S)}\bigr)
-\end{eqnarray*}
+$$
+\begin{aligned}
+    \Pr\bigl(x_S = x^{(S)}, \ldots x_0=x^{(0)}\bigr) &= 
+    \prod_{s=1}^S P\bigl(x^{(s)}, x^{(s-1)}\bigr)\,  \pi\bigl(x^{(0)}\bigr)\\
+    &=
+    \prod_{s=1}^S P\bigl(x^{(s-1)}, x^{(s)}\bigr)\, \pi\bigl(x^{(S)}\bigr) \\
+    &= \Pr\bigl(x_S = x^{(0)}, \ldots x_0=x^{(S)}\bigr)
+\end{aligned}
+$$ {#eq-forward-backward}
 
 The probability of generating a Markov chain when starting in the stationary distribution is the same in forward and backward direction. This is why the Markov chain is called *reversible*.
 
@@ -183,9 +185,9 @@ Generate some initial $x^{(0)} \sim p^{(0)}$ and iterate for $s=1, 2, \ldots$:
 
 2. generate a uniform random number $u \sim \mathcal U(0, 1)$; if $u \le A\bigl(y, x^{(s-1)}\bigr)$ then *accept* and set $x^{(s)} = y$, else *reject* and set $x^{(s)} = x^{(s-1)}$. The acceptance probability is given by
 
-\begin{equation}\label{eq:MHaccept}
-A(y, x) = \min\left\{1, \frac{Q(x, y)}{Q(y, x)}\frac{p(y)}{p(x)} \right\}
-\end{equation}
+$$
+    A(y, x) = \min\left\{1, \frac{Q(x, y)}{Q(y, x)}\frac{p(y)}{p(x)} \right\}
+$$ {#eq-MHaccept}
 
 
 The MH algorithm is the first and most important Markov chain Monte Carlo (MCMC) algorithm. Most other MCMC algorithms are specialized versions of MH sampling. 
@@ -202,9 +204,9 @@ The MH algorithm is the first and most important Markov chain Monte Carlo (MCMC)
 
 5. We don't need to know the normalizing constants of the target distribution and the proposal chain, since the MH algorithm only involves *ratios* of the target distribution and the transition rates of the proposal chain. If the unnormalized target and proposal chain are denoted 
     
-    \begin{equation}\label{eq:unnormalized}
+$$
     p(x) = \frac{1}{Z_p} p^*(x), \,\,\, Q(x, y) = \frac{1}{Z_Q} Q^*(x, y)
-    \end{equation}
+$$ {#eq-unnormalized}
 
 where $p^*(x) \ge 0$ and $Z_p = \sum_x p^*(x)$ etc., then the *acceptance ratio* is
 
@@ -267,15 +269,15 @@ The MH algorithm works because of the validity of the following statements:
 
 The MH algorithm generates a Markov chain on $\mathcal X$. The transition probabilities of the Markov chain are given by
 
-\begin{equation}\label{eq:MHtransitions}
+$$
 P(y, x) = Q(y, x)\, A(y, x) + \delta(y,x)\, r(x)
-\end{equation}
+$$ {#eq-MHtransitions}
 
 where the acceptance probability $A(y, x)$ is defined above, and the rejection probability is
 
-\begin{equation}\label{eq:MHrejection}
+$$
 r(x) = 1 - \sum_{y\in \mathcal X} Q(y, x)\, A(y, x)
-\end{equation}
+$$ {#eq-MHrejection}
 
 The transition probability of $y\not= x$ is $A(y, x)\, Q(y, x)$ by construction of the algorithm. The term for $y=x$ is obtained by subtracting the sum $\sum_y A(y, x)\, Q(y, x)$ from one, which is just $r(x)$. In general, it holds that the diagonal entries of the transition matrix are fixed by column stochasticity: 
 
@@ -287,16 +289,19 @@ So it is sufficient to know the off-diagonal elements.
 
 #### Stationarity of the target distribution
 
-To show that the target distribution $p(x)$ is indeed the stationary distribution of the Markov chain generated by the MH algorithm, we check if the transition matrix (\ref{eq:MHtransitions}) is $p$-reversible. For $y\not= x$ we have:
-\begin{eqnarray*}\label{eq:MHreversible}
-P(y, x)\, p(x) 
-&=& Q(y, x)\, A(y, x)\, p(x) \\
-&=& Q(y, x)\, \min\left\{1, \frac{Q(x, y)}{Q(y, x)}\frac{p(y)}{p(x)} \right\}\, p(x) \\
-&=&\min\left\{ Q(y, x)\, p(x), Q(x, y)\, p(y) \right\}\\
-&=& Q(x, y)\, \min\left\{1, \frac{Q(y, x)}{Q(x, y)}\frac{p(x)}{p(y)} \right\}\, p(y) \\
-&=& Q(x, y)\, A(x, y)\, p(y) \\
-&=& P(x, y)\, p(y)
-\end{eqnarray*}
+To show that the target distribution $p(x)$ is indeed the stationary distribution of the Markov chain generated by the MH algorithm, we check if the transition matrix (@eq-MHtransitions) is $p$-reversible. For $y\not= x$ we have:
+
+$$
+\begin{aligned}
+    P(y, x)\, p(x) 
+    &= Q(y, x)\, A(y, x)\, p(x) \\
+    &= Q(y, x)\, \min\left\{1, \frac{Q(x, y)}{Q(y, x)}\frac{p(y)}{p(x)} \right\}\, p(x) \\
+    &=\min\left\{ Q(y, x)\, p(x), Q(x, y)\, p(y) \right\}\\
+    &= Q(x, y)\, \min\left\{1, \frac{Q(y, x)}{Q(x, y)}\frac{p(x)}{p(y)} \right\}\, p(y) \\
+    &= Q(x, y)\, A(x, y)\, p(y) \\
+    &= P(x, y)\, p(y)
+\end{aligned}
+$$ {#eq-MHreversible}
 
 The MH chain satisfies the detailed balance equations with regard to our target distribution. Therefore, $p$ is a stationary distribution and will be sampled in the long run. 
 
@@ -389,39 +394,39 @@ Cons:
 
 The MH algorithm takes a base chain $Q$, the proposal chain, that does not yet have the desired target distribution $p$ and tweaks it in such a way that the new chain has the correct distribution. This is achieved by constructing a new chain $P$ that is $p$-reversible:
 
-\begin{equation}\label{eq:p-reversible}
+$$
     P(x, y)\, p(y) = P(y, x)\, p(x)
-\end{equation}
+$$ {#eq-p-reversible}
 
 The mapping from $Q$ to $P$ involves the acceptance ratio
 
-\begin{equation}\label{eq:acceptance-ratio}
+$$
     R(y, x) = \frac{Q(x, y)\, p(y)}{Q(y, x)\, p(x)}
-\end{equation}
+$$ {#eq-acceptance-ratio}
 
 and is defined as
 
-\begin{equation}\label{eq:metropolized}
+$$
 P(y, x) = \left\{
 \begin{array}{c c}
 Q(y, x)\, \min\{1, R(y, x)\} & \text{ if } y\not= x \\
 \sum_z Q(z, x) \bigl(1 - \min\{1, R(z, x)\}\bigr) & \text{ if } y=x\\ 
 \end{array}\right.
-\end{equation}
+$$ {#eq-metropolized}
 
 If $Q$ is irreducible, then $P$ is also irreducible. 
 
-The acceptance ratio $R(y, x)$ (Eq. \ref{eq:acceptance-ratio}) assesses how unbalanced the proposal chain is, i.e. how strongly $Q$ deviates from $p$-reversibility. If $Q$ were already $p$-reversible, then the ratio $R$ would always be one, and the proposal would always be accepted. The larger $R(y, x)$ deviates from one, the more unbalanced is the proposal chain with regard to the target. Since $R(x, y) = 1 / R(y, x)$, a strong flux of probability in one direction, results in a reduced flux of probability in the backwards direction. 
+The acceptance ratio $R(y, x)$ (Eq. @eq-acceptance-ratio) assesses how unbalanced the proposal chain is, i.e. how strongly $Q$ deviates from $p$-reversibility. If $Q$ were already $p$-reversible, then the ratio $R$ would always be one, and the proposal would always be accepted. The larger $R(y, x)$ deviates from one, the more unbalanced is the proposal chain with regard to the target. Since $R(x, y) = 1 / R(y, x)$, a strong flux of probability in one direction, results in a reduced flux of probability in the backwards direction. 
 
 To better understand how the mapping from some irreducible proposal chain $Q$ to a $p$-reversible Metropolis chain $P$ works, let me try to explain a very nice paper by [Billera & Diaconis: A Geometric Interpretation of the Metropolis-Hastings Algorithm](https://projecteuclid.org/euclid.ss/1015346318). This paper sets out to provide a global view on why the MH algorithm in some sense provides the optimal way of turning some arbitrary Markov chain $Q$ into a Markov chain with the desired stationary distribution. 
 
-First let us think of the space of all possible Markov chains indexed by states from the finite sample space $\mathcal X$. This space is formed by left stochastic square matrices of size $|\mathcal X|$ and will be called $\mathcal S(\mathcal X)$. $\mathcal S(\mathcal X)$ is convex, because the convex combination of two Markov matrices is again a stochastic matrix. The dimension of $\mathcal S(\mathcal X)$ is $|\mathcal X|(|\mathcal X| -1 )$: there are $|X|^2$ non-negative entries in total from which we need to subtract $|X|$ diagonal entries that are fixed by column stochasticity (Eq. \ref{eq:leftstochastic}).
+First let us think of the space of all possible Markov chains indexed by states from the finite sample space $\mathcal X$. This space is formed by left stochastic square matrices of size $|\mathcal X|$ and will be called $\mathcal S(\mathcal X)$. $\mathcal S(\mathcal X)$ is convex, because the convex combination of two Markov matrices is again a stochastic matrix. The dimension of $\mathcal S(\mathcal X)$ is $|\mathcal X|(|\mathcal X| -1 )$: there are $|X|^2$ non-negative entries in total from which we need to subtract $|X|$ diagonal entries that are fixed by column stochasticity (Eq. @eq-leftstochastic).
 
 For a fixed target distribution $p$, the subset $\mathcal R(p)$ of all Markov matrices that are $p$-reversible 
-\begin{equation}\label{eq:p-reversible-chains}
+$$
 \mathcal R(p) = \left\{ P \in \mathcal S(\mathcal X): P(x, y)\, p(y) = P(y, x)\, p(x) \right\}
-\end{equation}
-has dimension $|\mathcal X|(|\mathcal X| - 1) / 2$, because $p$-reversibility (Eq. \ref{eq:p-reversible}) fixes a triangular portion of the transition matrix
+$$ {#eq-p-reversible-chains}
+has dimension $|\mathcal X|(|\mathcal X| - 1) / 2$, because $p$-reversibility (Eq. @eq-p-reversible) fixes a triangular portion of the transition matrix
 
 $$
 P(y, x) = P(x, y) \frac{p(y)}{p(x)}
@@ -429,7 +434,7 @@ $$
 
 We can either choose $P(x, y)$ upon which $P(y, x)$ is fixed, or vice versa. $\mathcal R(p)$ is a convex subspace of $\mathcal S$: If $P, P' \in \mathcal R(p)$, then $\lambda P + (1-\lambda) P' \in \mathcal R(p)$ for $\lambda\in[0,1]$. 
 
-To get a visual impression, let us display the relevant matrix spaces for sample spaces with only two states (Eq. \ref{eq:twostate}). Due to the stochasticity constraints, 2-state Markov chains can be represented by points in a two-dimensional unit square. The axes of this space are spanned by $\alpha = \Pr(x_2|x_1)$ and $\beta=\Pr(x_1|x_2)$. The $p$-reversible chains form a one-dimensional subspace
+To get a visual impression, let us display the relevant matrix spaces for sample spaces with only two states (Eq. @eq-twostate). Due to the stochasticity constraints, 2-state Markov chains can be represented by points in a two-dimensional unit square. The axes of this space are spanned by $\alpha = \Pr(x_2|x_1)$ and $\beta=\Pr(x_1|x_2)$. The $p$-reversible chains form a one-dimensional subspace
 
 $$
 \mathcal R(p) = \left\{(\alpha, \beta) \in [0,1]^2 : \beta = \frac{p(x_1)}{p(x_2)}\,\alpha  \right\}
@@ -475,11 +480,11 @@ fig.tight_layout()
 
 The Metropolis-Hastings algorithm maps an irreducible proposal chain $Q$ to $\mathcal R(p)$
 
-\begin{equation}\label{eq:Metropolis-map}
+$$
 M[Q](y, x) = \min\left\{Q(y, x), \frac{p(y)}{p(x)}\,Q(x, y) \right\}
-\end{equation}
+$$ {#eq-Metropolis-map}
 
-for $y\not= x$ (the diagonal entries are fixed by column stochasticity (Eq. \ref{eq:leftstochastic})). The function $M: \mathcal S(\mathcal X) \to \mathcal R(p)$ is called *Metropolis map*. For a two-state system, the map is simply
+for $y\not= x$ (the diagonal entries are fixed by column stochasticity (Eq. @eq-leftstochastic)). The function $M: \mathcal S(\mathcal X) \to \mathcal R(p)$ is called *Metropolis map*. For a two-state system, the map is simply
 
 $$
 \begin{pmatrix}
@@ -509,17 +514,17 @@ fig.tight_layout()
 
 By construction, the off-diagonal entries in the Metropolis chain $M[Q]$ are *coordinate-wise decreasing*:
 
-\begin{equation}\label{eq:coordinatewise-decreasing}
+$$
 M[Q](y, x) \le Q(y, x)\,\,\,\text{for all}\,\, x, y \in \mathcal X \, .
-\end{equation}
+$$ {#eq-coordinatewise-decreasing}
 
 In the above figure, $Q$ is either shifted to the left along the $\alpha$ axis, i.e. towards smaller $P(x_2, x_1)$ values until $\mathcal{R}(p)$ is hit, or $Q$ is shifted downwards long the $\beta$ axis. 
 
 A suitable metric on $\mathcal S(\mathcal{X})$ is
 
-\begin{equation}\label{eq:metric}
+$$
 d(P, P') = \sum_{x\in\mathcal{X}} \sum_{y\not= x} p(x)\, \left|P(y, x) - P'(y, x)\right|
-\end{equation}
+$$ {#eq-metric}
 
 which is only zero, if $P'=P$. The following figure shows "circles" around some $Q\in\mathcal S(\mathcal X)$ which are of course not actual circles because $d(P,P')$ is a weighted L1 norm, so $d$-circles are diamonds.  
 
@@ -576,7 +581,7 @@ for Q in [(0.1, 0.8), (0.8, 0.2), (0.9, 0.5), (0.5, 0.5)][:4]:
 fig.tight_layout()
 ```
 
-Billera and Diaconis demonstrate that the Metropolis map minimizes the distance $d(Q,P)$ between the proposal chain $Q$ and all $P\in\mathcal{R}(p)$. Among all minimizers in the set of $p$-reversible chains, it picks the unique element that is coordinate-wise decreasing (Eq. \ref{eq:coordinatewise-decreasing}). It makes sense to demand that the mapping is coordinate-wise decreasing, because otherwise it will be more difficult to guarantee that the mapped chain is still in $\mathcal S(\mathcal X)$. 
+Billera and Diaconis demonstrate that the Metropolis map minimizes the distance $d(Q,P)$ between the proposal chain $Q$ and all $P\in\mathcal{R}(p)$. Among all minimizers in the set of $p$-reversible chains, it picks the unique element that is coordinate-wise decreasing (Eq. @eq-coordinatewise-decreasing). It makes sense to demand that the mapping is coordinate-wise decreasing, because otherwise it will be more difficult to guarantee that the mapped chain is still in $\mathcal S(\mathcal X)$. 
 
 ### Variations of Metropolis-Hastings
 

--- a/lectures/06-Gibbs-Sampling.qmd
+++ b/lectures/06-Gibbs-Sampling.qmd
@@ -261,19 +261,19 @@ fig.tight_layout()
 
 Let $P_i$ be $N$ Markov chains that share the same stationary distribution $\pi$:
 
-\begin{equation}\label{eq:multiple_chains}
+$$
 P_i \pi = \pi, \,\,\, \mathbb{1}^T\!P_i = \mathbb{1}^T
-\end{equation}
+$$ {#eq-multiple_chains}
 
 The product of all chains, $P=\prod_i P_i$ (here $\prod_i$ symbolizes a *matrix product*), is also a Markov chain with the same stationary distribution:
 
-\begin{equation}\label{eq:product_chain}
+$$
 P\pi = \pi, \,\,\, \mathbb{1}^T\!P = \mathbb{1}^T
-\end{equation}
+$$ {#eq-product_chain}
 
 Therefore, the following algorithm will simulate $P$ and therefore eventually $\pi$:
 
-\begin{align}\label{eq:markov-sequence}
+\begin{align}\label{eq-markov-sequence}
 \begin{split}
   \tilde{x}^{(1)} &\sim P_1\bigl(\,\cdot\,, x^{(s)}\bigr) \\
   \tilde{x}^{(2)} &\sim P_2\bigl(\,\cdot\,, \tilde{x}^{(1)}\bigr) \\
@@ -288,33 +288,33 @@ Let's look at a special but important case. Assume that the sample space decompo
 
 By $x_{\setminus i}$ we denote the variable vector obtained by omitting the $i$-th variable (or group of variables):
 
-\begin{equation}\label{eq:without-group}
+$$
 x_{\setminus i} := \begin{pmatrix}x_1, \ldots, x_{i-1}, x_{i+1}, \ldots, x_N \end{pmatrix}
-\end{equation}
+$$ {#eq-without-group}
 
 Then $x_{\setminus i}$ follows the marginal distribution:
 
-\begin{equation}\label{eq:without-group-marginal}
+$$
 p_{\setminus i}(x_{\setminus i}) = \int p(x_1, \ldots, x_N)\, d x_i
-\end{equation}
+$$ {#eq-without-group-marginal}
 
 The marginal distribution of $x_i$ is:
 
-\begin{equation}\label{eq:group-marginal}
+$$
 p_{i}(x_{i}) = \int p(x_1, \ldots, x_N)\, d x_{\setminus i}
-\end{equation}
+$$ {#eq-group-marginal}
 
 The conditional distribution of $x_i$ also readily available:
 
-\begin{equation}\label{eq:group-conditional}
+$$
 p_{i}(x_{i}|x_{\setminus i}) = \frac{p(x)}{p_{\setminus i}(x_{\setminus i})}
-\end{equation}
+$$ {#eq-group-conditional}
 
 Let us consider a sequence of $N$ Markov chains $P_i$ where each chain only updates $x_i$ and does not change $x_{\setminus i}$:
 
-\begin{equation}\label{eq:chain-group}
+$$
 Q_i(y, x) = q_i(y_i, x_i; x_{\setminus i})\, \delta(y_{\setminus i} - x_{\setminus i})  
-\end{equation}
+$$ {#eq-chain-group}
 
 where we introduced a product of delta distributions:
 
@@ -326,7 +326,7 @@ and $q_i(y_i, x_i; x_{\setminus i})$ is a Markov kernel on $\mathcal X_i \times 
 
 The Metropolis map of $Q_i(y, x)$ is
 
-\begin{align}\label{eq:coordinatewise-map}
+\begin{align}\label{eq-coordinatewise-map}
 \begin{split}
 M[Q_i](y, x) 
 &= \min\left\{Q_i(y, x), Q_i(x, y) \frac{p(y)}{p(x)} \right\} \\
@@ -337,7 +337,7 @@ M[Q_i](y, x)
 
 If we run the Metropolis-Hastings algorithm with $Q_i$, we simulate a Markov chain only on the conditional distribution of the $i$-th variable (or group of variables). This involves a Markov kernel $q_i$ on the corresponding subspace $\mathcal X_i$ that could, in principle, depend on all of the current variables. 
 
-This produces a Markov chain with the correct stationary distribution, but since $Q_i$ changes only the $i$-th variable, the resulting Markov chain is not ergodic. The trick is to update each parameter group successively using $Q_i$ in each subspace $\mathcal X_i$, and thereby produce a sequence of Metropolis maps, $M[Q_i]$, that share a common target distribution. Simulation of $M[Q_i]$ one after the other generates a simulation of the product chain, in a fashion analogous to equation (\ref{eq:markov-sequence}). This scheme is sometimes called *Metropolis-within-Gibbs*. 
+This produces a Markov chain with the correct stationary distribution, but since $Q_i$ changes only the $i$-th variable, the resulting Markov chain is not ergodic. The trick is to update each parameter group successively using $Q_i$ in each subspace $\mathcal X_i$, and thereby produce a sequence of Metropolis maps, $M[Q_i]$, that share a common target distribution. Simulation of $M[Q_i]$ one after the other generates a simulation of the product chain, in a fashion analogous to equation (\ref{eq-markov-sequence}). This scheme is sometimes called *Metropolis-within-Gibbs*. 
 
 Let's apply the coordinate-wise sampling scheme to the banana-shaped distribution using uniform proposals in each direction:
 
@@ -407,7 +407,7 @@ $$
 q_i(y_i, x_i; x_{\setminus i}) = p_i(y_i | x_{\setminus i})
 $$
 
-The acceptance ratio in the Metropolis map $M[Q_i]$ (Eq. \ref{eq:coordinatewise-map}) simplifies to 
+The acceptance ratio in the Metropolis map $M[Q_i]$ (Eq. \ref{eq-coordinatewise-map}) simplifies to 
 
 $$
 \frac{q_i(x_i, y_i; x_{\setminus i})}{q_i(y_i, x_i; x_{\setminus i})} \frac{p_i(y_i|x_{\setminus i})}{p_i(x_i|x_{\setminus i})} =
@@ -420,7 +420,7 @@ That is, all proposals are accepted - Gibbs sampling is rejection-free.
 
 Let $p(x_1, \ldots, x_N)$ be the joint distribution of $N$ random variables or groups of random variables $x_i\in\mathcal X_i$ with conditional distributions $p_i(x_i | x_{\setminus i})$, then the following iterative algorithm simulates a Markov chain whose stationary distribution is $p(x_1, \ldots, x_N)$:
 
-\begin{align}\label{eq:gibbs-sampling}
+\begin{align}\label{eq-gibbs-sampling}
 \begin{split}
   x^{(s+1)}_1 &\sim p_1\bigl(\,\cdot\, | x^{(s)}_{\setminus 1}\bigr) \\
   x^{(s+1)}_2 &\sim p_2\bigl(\,\cdot\, | {x}^{(s,s+1)}_{\setminus 2}\bigr) \\
@@ -437,7 +437,7 @@ so ${x}^{(s,s+1)}_{\setminus N} = x^{(s+1)}_{\setminus N}$.
 
 #### Collapsed Gibbs Sampler
 
-A variant of the Gibbs sampler (Eq. \ref{eq:gibbs-sampling}) is the [*collapsed Gibbs sampler*](https://en.wikipedia.org/wiki/Gibbs_sampling#Collapsed_Gibbs_sampler) where some of the conditional distributions $p_i(x_i | x_{\setminus i})$ are replaced by a marginal distribution, e.g. $p_i(x_i) = \int p(x_1, \ldots, x_N) dx_{\setminus i}$. This scheme is equally valid and rejection-free. See also the original paper by [Jun S. Liu](https://www.tandfonline.com/doi/abs/10.1080/01621459.1994.10476829).
+A variant of the Gibbs sampler (Eq. \ref{eq-gibbs-sampling}) is the [*collapsed Gibbs sampler*](https://en.wikipedia.org/wiki/Gibbs_sampling#Collapsed_Gibbs_sampler) where some of the conditional distributions $p_i(x_i | x_{\setminus i})$ are replaced by a marginal distribution, e.g. $p_i(x_i) = \int p(x_1, \ldots, x_N) dx_{\setminus i}$. This scheme is equally valid and rejection-free. See also the original paper by [Jun S. Liu](https://www.tandfonline.com/doi/abs/10.1080/01621459.1994.10476829).
 
 #### Example: Sampling a bivariate Gaussian model
 
@@ -664,7 +664,7 @@ $$
 
 Why is this helpful? We can use Gibbs sampling to generate samples from $p(x, y)$:
 
-\begin{align}\label{eq:gibbs-auxiliary}
+\begin{align}\label{eq-gibbs-auxiliary}
 \begin{split}
 x^{(s+1)} &\sim p\bigl(x | y^{(s)}\bigr) \\
 y^{(s+1)} &\sim p\bigl(y | x^{(s+1)}\bigr) \\
@@ -685,12 +685,14 @@ with a normalization constant $Z(\nu)$ that depends on the degrees of freedom $\
 
 This integral can be written as a [scale-mixture of normals](https://www.jstor.org/stable/2984774?seq=1#metadata_info_tab_contents):
 
-\begin{eqnarray*}
-f(x ; \alpha, \beta) &=& \int \underbrace{\sqrt{\frac{s}{2\pi}}\, e^{-\frac{s}{2} x^2 }}_{\text{Gaussian}}\,\,\, \underbrace{\frac{\beta^\alpha}{\Gamma(\alpha)} s^{\alpha -1} e^{-\beta s}}_{\text{Gamma distribution}} ds \\
-&=& \frac{\beta^\alpha}{\Gamma(\alpha)\,\sqrt{2\pi}} \int s^{\frac{2\alpha + 1}{2} - 1}\,\, \exp\left\{-s(\beta + x^2/2)\right\} ds \\
-&=& \frac{\beta^\alpha}{\Gamma(\alpha)\,\sqrt{2\pi}} \frac{\Gamma(\alpha+1/2)}{\left(\beta + x^2/2\right)^{\frac{2\alpha+1}{2}}} \\
-&=& \frac{1}{\sqrt{2\pi\beta}} \frac{\Gamma(\alpha+1/2)}{\Gamma(\alpha)} \left(1 + x^2/2\beta\right)^{-(\frac{2\alpha+1}{2})} \\
-\end{eqnarray*}
+$$
+\begin{aligned}
+    f(x ; \alpha, \beta) &= \int \underbrace{\sqrt{\frac{s}{2\pi}}\, e^{-\frac{s}{2} x^2 }}_{\text{Gaussian}}\,\,\, \underbrace{\frac{\beta^\alpha}{\Gamma(\alpha)} s^{\alpha -1} e^{-\beta s}}_{\text{Gamma distribution}} ds \\
+    &= \frac{\beta^\alpha}{\Gamma(\alpha)\,\sqrt{2\pi}} \int s^{\frac{2\alpha + 1}{2} - 1}\,\, \exp\left\{-s(\beta + x^2/2)\right\} ds \\
+    &= \frac{\beta^\alpha}{\Gamma(\alpha)\,\sqrt{2\pi}} \frac{\Gamma(\alpha+1/2)}{\left(\beta + x^2/2\right)^{\frac{2\alpha+1}{2}}} \\
+    &= \frac{1}{\sqrt{2\pi\beta}} \frac{\Gamma(\alpha+1/2)}{\Gamma(\alpha)} \left(1 + x^2/2\beta\right)^{-(\frac{2\alpha+1}{2})}
+\end{aligned}
+$$
 
 So $f(x; \alpha, \beta)$ is identical to $p(x|\nu)$ for $\alpha=\nu/2$ and $\beta=\nu/2$.
 

--- a/lectures/07-Hamiltonian-Monte-Carlo.qmd
+++ b/lectures/07-Hamiltonian-Monte-Carlo.qmd
@@ -39,7 +39,7 @@ $$
 
 Why is this helpful? We can use Gibbs sampling to generate samples from $p(x, y)$:
 
-\begin{align}\label{eq:gibbs-auxiliary2}
+\begin{align}\label{eq-gibbs-auxiliary2}
 \begin{split}
 x^{(s+1)} &\sim p\bigl(x | y^{(s)}\bigr) \\
 y^{(s+1)} &\sim p\bigl(y | x^{(s+1)}\bigr) \\
@@ -299,9 +299,9 @@ Another auxiliary variable method is [Hamiltonian Monte Carlo (HMC)](https://en.
 
 The idea of HMC is to exploit the following physical analogy: we interpret 
 
-\begin{equation}\label{eq:energy-hmc}
+$$
 E(x) = - \log p(x)
-\end{equation}
+$$ {#eq-energy-hmc}
 
 as a potential energy function of a physical system with degrees of freedom $x$. Typically, $x\in\mathbb{R}^D$.
 
@@ -313,15 +313,15 @@ $$
 
 and construct the joint distribution:
 
-\begin{equation}\label{eq:hmc-joint}
+$$
 p(x, v) = p(x)\, p(v) \propto \exp\left\{- E(x) - \|v\|^2 / 2 \right\}\, .
-\end{equation}
+$$ {#eq-hmc-joint}
 
 It seems that we didn't gain anything by introducing $v$ other than artificially blowing up the problem and writing the joint distribution in some fancy, pseudo-physical way. However, the major insight comes from the fact that if we stretch the physical analogy further, the joint distribution can be viewed as the [canonical ensemble](https://en.wikipedia.org/wiki/Canonical_ensemble) defined over [*phase space*](https://en.wikipedia.org/wiki/Phase_space):
 
-\begin{equation}\label{eq:hmc-hamiltonian}
+$$
 p(x, v) \propto \exp\left\{- H(x, v)\right\}\,\,\,\text{where}\,\,\,  H(x, v) := \underbrace{\tfrac{1}{2} \|v\|^2}_{\text{kinetic energy}} + \underbrace{E(x)}_{\text{potential energy}}\, .
-\end{equation}
+$$ {#eq-hmc-hamiltonian}
 
 Phase space is the joint space of positions $x$ and momenta (velocities) $v$ in our physical analogy, and the total energy is given by the sum of the kinetic and potential energy is called the [*Hamiltonian*](https://en.wikipedia.org/wiki/Hamiltonian_mechanics) of the system. 
 
@@ -329,7 +329,7 @@ Phase space is the joint space of positions $x$ and momenta (velocities) $v$ in 
 
 Classical systems with $D$ degrees of freedom evolve in time by the action of the Hamiltonian $H(x, v)$. Trajectories in phase space are given by the time evolution of velocities and positions, $v(t)$ and $x(t)$. The dynamics of the system is described by Hamilton's equations of motion (an elegant generalization of Newton dynamics):
 
-\begin{align}\label{eq:hmc-dynamics}
+\begin{align}\label{eq-hmc-dynamics}
 \begin{split}
 \dot{v} &= \frac{d}{dt} v = - \nabla_x H(x, v) \\
 \dot{x} &= \frac{d}{dt} x = + \nabla_v H(x, v) \\
@@ -338,7 +338,7 @@ Classical systems with $D$ degrees of freedom evolve in time by the action of th
 
 where $d/dt$ is the derivative with respect to time $t$ and abbreviated by a dot (as in $\dot{x}$), and $\nabla_x, \nabla_v$ are the gradients with respect to positions $x$ and momenta $v$. 
 
-The hallmark of Hamiltonian dynamics (Eq. \ref{eq:hmc-dynamics}) of an isolated classical system is that it conserves the total energy. This is clear from
+The hallmark of Hamiltonian dynamics (Eq. \ref{eq-hmc-dynamics}) of an isolated classical system is that it conserves the total energy. This is clear from
 
 $$
 \frac{d}{dt} H = (\nabla_x H(x, v))^T\dot{x} + (\nabla_v H(x, v))^T\dot{v} = (\nabla_x H)^T\!(\nabla_v H) - (\nabla_v H)^T\!(\nabla_x H) = 0
@@ -387,9 +387,9 @@ with the following dynamics:
 
 In matrix-vector form we have
 
-\begin{equation}\label{eq:oscillator}
+$$
 \frac{d}{dt} \begin{pmatrix} v\\ x\end{pmatrix} = \begin{pmatrix} 0 & -k \\ 1 & 0 \\ \end{pmatrix} \begin{pmatrix} v\\ x\end{pmatrix} = A \begin{pmatrix} v\\ x\end{pmatrix}\,\,\,\Rightarrow\,\,\, \begin{pmatrix} v(t)\\ x(t)\end{pmatrix} = \exp\{tA\} \begin{pmatrix} v_0\\ x_0\end{pmatrix}
-\end{equation}
+$$ {#eq-oscillator}
 
 where $\exp\{tA\}$ is a matrix exponential $\exp\{tA\} = \sum_n \frac{t^n}{n!} A^n$. The matrix powers have a simple structure: 
 
@@ -399,7 +399,7 @@ $$
 
 So the solution of the Hamilton equations is (with $\omega = \sqrt{k}$):
 
-\begin{eqnarray*}\label{eq:oscillator2}
+\begin{eqnarray*}\label{eq-oscillator2}
 \begin{pmatrix} v(t)\\ x(t)\end{pmatrix} &=& I \sum_{n} \frac{(-)^n}{(2n)!} (\omega t)^{2n} \begin{pmatrix} v_0\\ x_0\end{pmatrix} + \omega^{-1}A \sum_{n} \frac{(-)^n}{(2n+1)!} (\omega t)^{2n+1} \begin{pmatrix} v_0\\ x_0\end{pmatrix} \\
 &=& \biggl(I \cos(\omega t) + \omega^{-1}A \sin(\omega t)\biggr) \begin{pmatrix} v_0\\ x_0\end{pmatrix} \\
 &=& \begin{pmatrix} \cos(\omega t) & -\omega\sin(\omega t)\\ \sin(\omega t)/\omega  & \cos(\omega t) \\ \end{pmatrix} \begin{pmatrix} v_0\\ x_0\end{pmatrix} 

--- a/lectures/08-HMC-Practical-Issues.qmd
+++ b/lectures/08-HMC-Practical-Issues.qmd
@@ -54,7 +54,7 @@ The crucial feature for making HMC work properly is the conservation of phase sp
 
 [Leapfrog integration](https://en.wikipedia.org/wiki/Leapfrog_integration) is a simple symplectic integration scheme that is often used as an integrator in HMC. The leapfrog integrator solves a finite-difference version of Hamilton's equations of motion:
 
-\begin{align}\label{eq:leapfrog}
+\begin{align}\label{eq-leapfrog}
 \begin{split}
 v(t+\epsilon/2) &= v(t) - (\epsilon/2) \nabla_x E(x(t)) \\
 x(t+\epsilon) &= x(t) + \epsilon v(t+\epsilon/2) \\
@@ -734,11 +734,11 @@ fig.tight_layout()
 
 The speed of convergence of a Markov chain $P$ with stationary distribution $\pi$ depends on how quickly contributions to the distance
 
-\begin{equation}\label{eq:distance}
+$$
 \left|p^{(S)} - \pi\right|
-\end{equation}
+$$ {#eq-distance}
 
-die out as $S\to\infty$. Distance (\ref{eq:distance}) is dominated by the second largest eigenvalue $\lambda_2$ of $P$. Since the Markov chain is assumed to be irreducible and aperiodic, we have strictly $|\lambda_2| < 1$. If $u_2, u_3, \ldots$ are the eigenvectors of $P$ with eigenvalues $1 > |\lambda_2| \ge |\lambda_3| >\ldots$, then we can write the initial distribution as
+die out as $S\to\infty$. Distance (@eq-distance) is dominated by the second largest eigenvalue $\lambda_2$ of $P$. Since the Markov chain is assumed to be irreducible and aperiodic, we have strictly $|\lambda_2| < 1$. If $u_2, u_3, \ldots$ are the eigenvectors of $P$ with eigenvalues $1 > |\lambda_2| \ge |\lambda_3| >\ldots$, then we can write the initial distribution as
 $$
 p^{(0)} = \pi + a_2 u_2 + a_3 u_3 + \ldots
 $$
@@ -831,34 +831,34 @@ $$
 $$
 and the difference can be substantial for small $s$, thereby inducing significant bias to the Monte Carlo estimator:
 
-\begin{equation}
+$$
 \frac{1}{S} \sum_{s=1}^S f\bigl(x^{(s)}\bigr).
-\end{equation}
+$$
 
 It is difficult to assess the reliability of MCMC approximations, because of the dependence of the samples $x^{(s)}$. The dependence usually adds variance to the estimator, when compared against simple Monte Carlo averages.
 
 To minimize biases stemming from a poor choice of the initial distribution $p^{(0)}$, it is common practice to discard the first samples $x^{(0)}, \ldots, x^{(B)}$ called *burn-in*. It is assumed that $x^{(B+1)}$ will approximately follow the target distribution $p$. The Monte Carlo approximation then becomes:
-\begin{equation}\label{eq:burnin}
+$$
 \frac{1}{S-B} \sum_{s=B+1}^S f\bigl(x^{(s)}\bigr)\, .
-\end{equation}
+$$ {#eq-burnin}
 Several statistics can be used to detect bias in MCMC simulations. However, they usually rely on rather strong assumptions, such as the asymptotic normality, or at least uni-modality of the target.
 
 ### Auto-correlation diagnostic
 
 The asymptotic variance of the MCMC estimator can be shown to converge against
-\begin{equation}\label{eq:variance}
+$$
 \text{var}\left[\frac{1}{S}\sum_s f\bigl(x^{(s)}\bigr) \right] \xrightarrow[S\to\infty]{} \frac{1}{S} \text{var}_p[f] (1 + 2 \sum_{s\ge 1} \rho_s)  
-\end{equation}
+$$ {#eq-variance}
 where $\rho_s$ are the *correlations* between the initial samples and the $s$-th samples
-\begin{equation}\label{eq:correlation}
+$$
 \rho_s = \text{corr}[f(x^{(0)}), f(x^{(s)})] \, .
-\end{equation}
+$$ {#eq-correlation}
 For uncorrelated samples $\rho_s=0$ and we are back to the standard variance of Monte Carlo estimators: $\text{var}[f]/S$. However, due to correlations the variance can be increased significantly (in principle, the variance can approach infinity for perfectly correlated samples). 
 
 Another way to look at this is that correlations decrease the *effective sample size* (ESS), which becomes
-\begin{equation}\label{eq:ess}
+$$
 S_{\text{eff}} = \frac{S}{1 + 2 \sum_{s\ge 1} \rho_s} = \frac{S}{\text{IACT}}
-\end{equation}
+$$ {#eq-ess}
 where $\text{IACT} = 1 + 2 \sum_{s\ge 1} \rho_s$ is the *integrated auto-correlation time*. 
 
 ```{python}


### PR DESCRIPTION
This addresses #3 

quarto wants equations in `$$` environments, and equation labels can be added as `{#eq-mylabel}` right at the end of the equation environment (the closing `$$`). See https://quarto.org/docs/authoring/cross-references.html#equations

In the same way instead of a `\ref{mylabel}`, quarto wants `@eq-mylabel` to reference equations labeled as above.

I've done the replacement in this PR for most equations.
But some were not straightforward to fix, I think one `eqnarray*` and the rest `align/split`. I left those for now.

This means the pdf should now correctly show all references, but the HTML render can't handle 4.